### PR TITLE
remove ipam config from ovn-vpc-external-network definition

### DIFF
--- a/docs/guide/vpc.en.md
+++ b/docs/guide/vpc.en.md
@@ -128,18 +128,12 @@ spec:
       "cniVersion": "0.3.0",
       "type": "macvlan",
       "master": "eth1",
-      "mode": "bridge",
-      "ipam": {
-        "type": "kube-ovn",
-        "server_socket": "/run/openvswitch/kube-ovn-daemon.sock",
-        "provider": "ovn-vpc-external-network.kube-system"
-      }
+      "mode": "bridge"
     }'
 ```
 
 - This Subnet is used to manage the available external addresses, so please communicate with your network management to give you the available physical segment IPs.
 - The VPC gateway uses Macvlan for physical network configuration, and `master` of `NetworkAttachmentDefinition` should be the NIC name of the corresponding physical network NIC.
-- `provider` format is `<NetworkAttachmentDefinition Name>.<NetworkAttachmentDefinition Namespace>`.
 - `name` must be `ovn-vpc-external-network`.
 
 ### Enabling the VPC Gateway

--- a/docs/guide/vpc.md
+++ b/docs/guide/vpc.md
@@ -125,18 +125,12 @@ spec:
       "cniVersion": "0.3.0",
       "type": "macvlan",
       "master": "eth1",
-      "mode": "bridge",
-      "ipam": {
-        "type": "kube-ovn",
-        "server_socket": "/run/openvswitch/kube-ovn-daemon.sock",
-        "provider": "ovn-vpc-external-network.kube-system"
-      }
+      "mode": "bridge"
     }'
 ```
 
 - 该 Subnet 用来管理可用的外部地址，请和网络管理沟通给出可用的物理段 IP。
 - VPC 网关使用 Macvlan 做物理网络配置，`NetworkAttachmentDefinition` 的 `master` 需为对应物理网路网卡的网卡名。
-- `provider` 格式为 `<NetworkAttachmentDefinition Name>.<NetworkAttachmentDefinition Namespace>`。
 - `name` 必须为 ovn-vpc-external-network，这里代码中做了硬编码。
 
 ### 开启 VPC 网关功能


### PR DESCRIPTION
Since we use EIP to allocate external IP, there's no need to allocate a unpredictable external IP to VPC Gateway Pod  during Macvlan interface creation.

Current guide also cause waste of Public IP resource, for example, user may want one VPCGateway per Node to improve availability. Allocating  external IP at Macvlan interface creation waste N external IPs.