### PR TITLE
Optimize eip doc

### DIFF
--- a/docs/advance/ovn-eip-fip-snat.en.md
+++ b/docs/advance/ovn-eip-fip-snat.en.md
@@ -315,7 +315,9 @@ spec:
 # Dynamically allocate an eip resource that is reserved for fip dnat_and_snat scenarios
 ```
 
-When an additional public network is configured, you can specify the public network that needs to be expanded through externalSubnet. In the above configuration, external204 and extra are optional.
+The externalSubnet field does not need to be configured. If not configured, the default public network will be used. In the above configuration, the default public network is external204.
+
+If you want to use an additional public network, you need to explicitly specify the public network to be extended through externalSubnet. In the above configuration, the extended public network is extra.
 
 ### 2.1 Create an fip for pod
 
@@ -543,7 +545,7 @@ spec:
 
 ```
 
-When an additional public network is configured, you can specify the public network that needs to be expanded through externalSubnet. In the above configuration, external204 and extra are optional.
+If you want to use an additional public network, you need to explicitly specify the public network to be extended through externalSubnet. In the above configuration, the extended public network is extra.
 
 ### 3.2 ovn-snat corresponds to a pod IP
 
@@ -583,7 +585,7 @@ spec:
 
 ```
 
-When an additional public network is configured, you can specify the public network that needs to be expanded through externalSubnet. In the above configuration, external204 and extra are optional.
+If you want to use an additional public network, you need to explicitly specify the public network to be extended through externalSubnet. In the above configuration, the extended public network is extra.
 
 After the above resources are created, you can see the following resources that the snat public network feature depends on.
 
@@ -710,7 +712,7 @@ spec:
 
 ```
 
-When an additional public network is configured, you can specify the public network that needs to be expanded through externalSubnet. In the above configuration, external204 and extra are optional.
+If you want to use an additional public network, you need to explicitly specify the public network to be extended through externalSubnet. In the above configuration, the extended public network is extra.
 
 The configuration of OvnDnatRule is similar to that of IptablesDnatRule.
 

--- a/docs/advance/ovn-eip-fip-snat.md
+++ b/docs/advance/ovn-eip-fip-snat.md
@@ -312,7 +312,9 @@ spec:
 # 动态分配一个 eip 资源，该资源预留用于 fip 场景
 ```
 
-当配置了额外公网网络时，可以通过 externalSubnet 指定需要扩展使用的公网网络，在上述配置中，可选 external204 和 extra 两个公网网络
+externalSubnet 字段可不进行配置，若未配置则会使用默认公网网络，在上述配置中默认公网网络为 external204。
+
+若要使用额外公网网络，则需要通过 externalSubnet 显式指定需要扩展使用的公网网络，在上述配置中扩展公网网络为 extra。
 
 ### 2.1 ovn-fip 为 pod 绑定一个 fip
 
@@ -537,7 +539,7 @@ spec:
 
 ```
 
-当配置了额外公网网络时，可以通过 externalSubnet 指定需要扩展使用的公网网络，在上述配置中，可选 external204 和 extra 两个公网网络
+若要使用额外公网网络，则需要通过 externalSubnet 显式指定需要扩展使用的公网网络，在上述配置中扩展公网网络为 extra。
 
 ### 3.2 ovn-snat 对应到一个 pod ip
 
@@ -578,7 +580,7 @@ spec:
 
 ```
 
-当配置了额外公网网络时，可以通过 externalSubnet 指定需要扩展使用的公网网络，在上述配置中，可选 external204 和 extra 两个公网网络。
+若要使用额外公网网络，则需要通过 externalSubnet 显式指定需要扩展使用的公网网络，在上述配置中扩展公网网络为 extra。
 
 以上资源创建后，可以看到 snat 公网功能依赖的如下资源。
 
@@ -706,7 +708,7 @@ spec:
 
 ```
 
-当配置了额外公网网络时，可以通过 externalSubnet 指定需要扩展使用的公网网络，在上述配置中，可选 external204 和 extra 两个公网网络
+若要使用额外公网网络，则需要通过 externalSubnet 显式指定需要扩展使用的公网网络，在上述配置中扩展公网网络为 extra。
 
 OvnDnatRule 的配置与 IptablesDnatRule 类似
 


### PR DESCRIPTION
- [x] Make sure you have followed the [Document Convention](../docs/reference/document-convention.md).

In most cases, users will only use the default external network, so there is no need to explicitly specify externalSubnet when creating ovneip.

When the external Subnet field is empty, it will be set as the default external subnet. When you need to use an additional external network, you need to set it explicitly.