### PR TITLE
add default vpc subnet docs

### DIFF
--- a/docs/guide/vpc.en.md
+++ b/docs/guide/vpc.en.md
@@ -281,14 +281,14 @@ metadata:
   name: eipd01
 spec:
   natGwDp: gw1
-  
+
 ---
 kind: IptablesDnatRule
 apiVersion: kubeovn.io/v1
 metadata:
   name: dnat01
 spec:
-  eip: eipd01 
+  eip: eipd01
   externalPort: '8888'
   internalIp: 10.0.1.10
   internalPort: '80'
@@ -565,9 +565,9 @@ View resource information:
 
 ```bash
 [root@hci-dev-mst-1 kubeovn]# kubectl get vpc-dns
-NAME        ACTIVE   VPC         SUBNET   
-test-cjh1   false    cjh-vpc-1   cjh-subnet-1   
-test-cjh2   true     cjh-vpc-1   cjh-subnet-2 
+NAME        ACTIVE   VPC         SUBNET
+test-cjh1   false    cjh-vpc-1   cjh-subnet-1
+test-cjh2   true     cjh-vpc-1   cjh-subnet-2
 ```
 
 - `ACTIVE`: if the custom vpc-dns is ready.
@@ -577,3 +577,23 @@ test-cjh2   true     cjh-vpc-1   cjh-subnet-2
 - Only one custom DNS component will be deployed in one VPC;
 - When multiple VPC-DNS resources (i.e. different subnets in the same VPC) are configured in one VPC, only one VPC-DNS resource with status `true` will be active, while the others will be `false`;
 - When the `true` VPC-DNS is deleted, another `false` VPC-DNS will be deployed.
+
+## Default subnet selection for custom VPC
+
+If the custom VPC is running multiple Subnets, you can specify the default Subnet for that VPC.
+
+```yaml
+kind: Vpc
+apiVersion: kubeovn.io/v1
+metadata:
+  name: test-vpc-1
+spec:
+  namespaces:
+  - ns1
+  defaultSubnet: test
+```
+
+- `defaultSubnet`: Name of the subnet that should be used by custom VPC as the default one.
+
+Please note that it will annotate the VPC namespaces with just one logical switch using `"ovn.kubernetes.io/logical_switch"` annotation.
+Any of the new Pods without `"ovn.kubernetes.io/logical_switch"` annotation will be added to the default Subnet.

--- a/docs/reference/kube-ovn-api.en.md
+++ b/docs/reference/kube-ovn-api.en.md
@@ -201,6 +201,7 @@ In each CRD definition, the Condition field in Status follows the above format, 
 | policyRoutes | []*PolicyRoute | The policy route information configured under Vpc |
 | vpcPeerings | []*VpcPeering | Vpc interconnection information |
 | enableExternal | Bool | Whether vpc is connected to an external switch |
+| defaultSubnet | String | Name of the subnet that should be used by custom Vpc as the default one |
 
 ##### StaticRoute
 


### PR DESCRIPTION
- [x] Make sure you have followed the [Document Convention](../docs/reference/document-convention.md).
See also:
- https://github.com/kubeovn/kube-ovn/pull/4171
- https://github.com/kubeovn/kube-ovn/issues/4172