### PR TITLE
支持更灵活的使用方式,也是为了保证所有 ovn eip 的底层基本逻辑代码都一致

### DIFF
--- a/docs/guide/eip-snat.en.md
+++ b/docs/guide/eip-snat.en.md
@@ -19,6 +19,15 @@ External services can access the Pod directly through the EIP, and the Pod will 
 
 ![](../static/eip-snat.png)
 
+## Advanced Configuration
+
+> To support this feature, if you need to directly specify a default external subnet name, you may need to set startup arguments for kube-ovn-controller.
+Some args of `kube-ovn-controller` allow for advanced configuration of SNAT and EIP:
+
+- `--external-gateway-config-ns`: The Namespace of Configmap `ovn-external-gw-config`, default is `kube-system`.
+- `--external-gateway-net`: The name of the bridge to which the physical NIC is bridged, default is `external`.
+- `--external-gateway-vlanid`: Physical network Vlan Tag number, default is 0, i.e. no Vlan is used.
+
 ## Preparation
 
 - In order to use the OVN's L3 Gateway capability, a separate NIC must be bridged into the OVS bridge for overlay and underlay network communication.
@@ -38,6 +47,7 @@ metadata:
   namespace: kube-system
 data:
   enable-external-gw: "true"
+  # external-gw-switch: "external"
   external-gw-nodes: "kube-ovn-worker"
   external-gw-nic: "eth1"
   external-gw-addr: "172.56.0.1/16"
@@ -51,6 +61,7 @@ data:
 - `external-gw-nic`: The name of the NIC that performs the role of a gateway on the node.
 - `external-gw-addr`: The IP and mask of the physical network gateway.
 - `nic-ip`,`nic-mac`: The IP and Mac assigned to the logical gateway port needs to be an unoccupied IP and Mac for the physical subnet.
+- `external-gw-switch`: Reuse the name of an existing underlay subnet logical switch. If you are using the default external of `--external-gateway-net`, then this value is omitted. But if you want to reuse an existing underlay subnet CR, then you can just configure `external-gw-switch: "your-subnet-name"`, and the others can be left unconfigured, because the network has already been maintained through the underlay subnet.
 
 ## Confirm the Configuration Take Effect
 
@@ -127,11 +138,3 @@ kubectl annotate pod pod-gw ovn.kubernetes.io/routed-
 ```
 
 When the EIP or SNAT takes into effect, the `ovn.kubernetes.io/routed` annotation will be added back.
-
-## Advanced Configuration
-
-Some args of `kube-ovn-controller` allow for advanced configuration of SNAT and EIP:
-
-- `--external-gateway-config-ns`: The Namespace of Configmap `ovn-external-gw-config`, default is `kube-system`.
-- `--external-gateway-net`: The name of the bridge to which the physical NIC is bridged, default is `external`.
-- `--external-gateway-vlanid`: Physical network Vlan Tag number, default is 0, i.e. no Vlan is used.

--- a/docs/guide/eip-snat.en.md
+++ b/docs/guide/eip-snat.en.md
@@ -21,7 +21,7 @@ External services can access the Pod directly through the EIP, and the Pod will 
 
 ## Advanced Configuration
 
-> To support this feature, if you need to directly specify a default external subnet name, you may need to set startup arguments for kube-ovn-controller.
+> To support this feature, if you need to directly specify a default external subnet name, you may need to set the startup parameters of `kube-ovn-controller`.
 Some args of `kube-ovn-controller` allow for advanced configuration of SNAT and EIP:
 
 - `--external-gateway-config-ns`: The Namespace of Configmap `ovn-external-gw-config`, default is `kube-system`.
@@ -61,7 +61,7 @@ data:
 - `external-gw-nic`: The name of the NIC that performs the role of a gateway on the node.
 - `external-gw-addr`: The IP and mask of the physical network gateway.
 - `nic-ip`,`nic-mac`: The IP and Mac assigned to the logical gateway port needs to be an unoccupied IP and Mac for the physical subnet.
-- `external-gw-switch`: Reuse the name of an existing underlay subnet logical switch. If you are using the default external of `--external-gateway-net`, then this value is omitted. But if you want to reuse an existing underlay subnet CR, then you can just configure `external-gw-switch: "your-subnet-name"`, and the others can be left unconfigured, because the network has already been maintained through the underlay subnet.
+- `external-gw-switch`: Reuse the existing underlay subnet logical switch name. If you are using the non-CRD mode `--external-gateway-net` specified external, then you do not need to configure it. But if you want to reuse the existing underlay subnet CR, then you can just configure external-gw-switch: "your-subnet-name", and the others can be left unconfigured, because the network has been maintained through the underlay subnet.
 
 ## Confirm the Configuration Take Effect
 

--- a/docs/guide/eip-snat.md
+++ b/docs/guide/eip-snat.md
@@ -19,6 +19,16 @@ Kube-OVN 支持利用 OVN 中的 L3 Gateway 功能来实现 Pod 级别的 SNAT �
 
 ![](../static/eip-snat.png)
 
+## 高级配置
+
+> 为了支持该功能，如果你需要直接指定定一个默认的 external subnet 名，你可能需要设置 `kube-ovn-controller` 的启动参数。
+
+`kube-ovn-controller` 的部分启动参数可对 SNAT 和 EIP 功能进行高阶配置：
+
+- `--external-gateway-config-ns`: Configmap `ovn-external-gw-config` 所属 Namespace，默认为 `kube-system`。
+- `--external-gateway-net`: 物理网卡所桥接的网桥名，默认为 `external`。
+- `--external-gateway-vlanid`: 物理网络 Vlan Tag 号，默认为 0，即不使用 Vlan。
+
 ## 准备工作
 
 - 为了使用 OVN 的 L3 Gateway 能力，必须将一个单独的网卡接入 OVS 网桥中进行 Overlay 和 Underlay 网络的打通，
@@ -38,6 +48,7 @@ metadata:
   namespace: kube-system
 data:
   enable-external-gw: "true"
+  # external-gw-switch: "external"
   external-gw-nodes: "kube-ovn-worker"
   external-gw-nic: "eth1"
   external-gw-addr: "172.56.0.1/16"
@@ -51,6 +62,7 @@ data:
 - `external-gw-nic`: 节点上承担网关作用的网卡名。
 - `external-gw-addr`: 物理网络网关的 IP 和掩码。
 - `nic-ip`,`nic-mac`: 分配给逻辑网关端口的 IP 和 Mac，需为物理段未被占用的 IP 和 Mac。
+- `external-gw-switch`: 复用已有的 underlay subnet 逻辑交换机名称，如果使用的是`--external-gateway-net`默认的 external，那么该值是缺省的。但如果你想复用已有的 underlay subnet CR， 那么你可以只配置 external-gw-switch: "your-subnet-name"，其他的都可以不用配置，因为网络已经通过 underlay subnet 维护好了。
 
 ## 观察 OVN 和 OVS 状态确认配置生效
 
@@ -127,11 +139,3 @@ kubectl annotate pod pod-gw ovn.kubernetes.io/routed-
 ```
 
 当 EIP 或 SNAT 规则生效后，`ovn.kubernetes.io/routed` annotation 会被重新添加。
-
-## 高级配置
-
-`kube-ovn-controller` 的部分启动参数可对 SNAT 和 EIP 功能进行高阶配置：
-
-- `--external-gateway-config-ns`: Configmap `ovn-external-gw-config` 所属 Namespace，默认为 `kube-system`。
-- `--external-gateway-net`: 物理网卡所桥接的网桥名，默认为 `external`。
-- `--external-gateway-vlanid`: 物理网络 Vlan Tag 号，默认为 0，即不使用 Vlan。

--- a/docs/guide/eip-snat.md
+++ b/docs/guide/eip-snat.md
@@ -29,6 +29,8 @@ Kube-OVN 支持利用 OVN 中的 L3 Gateway 功能来实现 Pod 级别的 SNAT �
 - `--external-gateway-net`: 物理网卡所桥接的网桥名，默认为 `external`。
 - `--external-gateway-vlanid`: 物理网络 Vlan Tag 号，默认为 0，即不使用 Vlan。
 
+以上这些固定参数，只能维护一个默认的 external subnet，而且不是基于 subnet CRD 的形式，如果你需要以 CRD 的形式维护多个 external subnet，请参考[VPC OVN NAT 网关](../vpc/ovn-eip-fip-snat.md)。
+
 ## 准备工作
 
 - 为了使用 OVN 的 L3 Gateway 能力，必须将一个单独的网卡接入 OVS 网桥中进行 Overlay 和 Underlay 网络的打通，
@@ -62,7 +64,7 @@ data:
 - `external-gw-nic`: 节点上承担网关作用的网卡名。
 - `external-gw-addr`: 物理网络网关的 IP 和掩码。
 - `nic-ip`,`nic-mac`: 分配给逻辑网关端口的 IP 和 Mac，需为物理段未被占用的 IP 和 Mac。
-- `external-gw-switch`: 复用已有的 underlay subnet 逻辑交换机名称，如果使用的是`--external-gateway-net`默认的 external，那么该值是缺省的。但如果你想复用已有的 underlay subnet CR， 那么你可以只配置 external-gw-switch: "your-subnet-name"，其他的都可以不用配置，因为网络已经通过 underlay subnet 维护好了。
+- `external-gw-switch`: 复用已有的 underlay subnet 逻辑交换机名称，如果使用的是非 CRD 模式的`--external-gateway-net`指定的 external，那么不需要配置。但如果你想复用已有的 underlay subnet CR， 那么你可以只配置 external-gw-switch: "your-subnet-name"，其他的都可以不用配置，因为网络已经通过 underlay subnet 维护好了。
 
 ## 观察 OVN 和 OVS 状态确认配置生效
 


### PR DESCRIPTION
- [ ] Make sure you have followed the [Document Convention](../blob/master/docs/reference/document-convention.en.md)
