### PR TITLE
docs(veg): correct route example to LR policy, drop ECMP symmetric-reply

### DIFF
--- a/docs/vpc/vpc-egress-gateway.en.md
+++ b/docs/vpc/vpc-egress-gateway.en.md
@@ -192,7 +192,7 @@ tcpdump: listening on any, link-type LINUX_SLL2 (Linux cooked v2), snapshot leng
     172.17.0.1 > 10.16.0.9: ICMP echo reply, id 37989, seq 0, length 64
 ```
 
-Routing policies (static routes for custom VPCs) are automatically created on the OVN Logical Router:
+Routing policies are automatically created on the OVN Logical Router:
 
 ```shell
 $ kubectl ko nbctl lr-policy-list ovn-cluster
@@ -332,11 +332,10 @@ NAME                       READY   STATUS    RESTARTS   AGE     IP            NO
 gateway2-fcc6b8b87-8lgvx   1/1     Running   0          2m18s   192.168.0.3   kube-ovn-worker2   <none>           <none>
 gateway2-fcc6b8b87-wmww6   1/1     Running   0          2m18s   192.168.0.2   kube-ovn-worker    <none>           <none>
 
-$ kubectl ko nbctl lr-route-list vpc1
-IPv4 Routes
-Route Table <main>:
-           192.168.0.0/24               192.168.0.2 src-ip ecmp ecmp-symmetric-reply bfd
-           192.168.0.0/24               192.168.0.3 src-ip ecmp ecmp-symmetric-reply bfd
+$ kubectl ko nbctl lr-policy-list vpc1
+Routing Policies
+     29100                       ip4.src == 192.168.0.0/24         reroute                192.168.0.2, 192.168.0.3
+     29090                       ip4.src == 192.168.0.0/24            drop
 
 $ kubectl ko nbctl list bfd
 _uuid               : 223ede10-9169-4c7d-9524-a546e24bfab5

--- a/docs/vpc/vpc-egress-gateway.md
+++ b/docs/vpc/vpc-egress-gateway.md
@@ -192,7 +192,7 @@ tcpdump: listening on any, link-type LINUX_SLL2 (Linux cooked v2), snapshot leng
     172.17.0.1 > 10.16.0.9: ICMP echo reply, id 37989, seq 0, length 64
 ```
 
-OVN Logical Router 中会自动创建路由策略（自定义 VPC 中是静态路由）：
+OVN Logical Router 中会自动创建路由策略：
 
 ```shell
 $ kubectl ko nbctl lr-policy-list ovn-cluster
@@ -332,11 +332,10 @@ NAME                       READY   STATUS    RESTARTS   AGE     IP            NO
 gateway2-fcc6b8b87-8lgvx   1/1     Running   0          2m18s   192.168.0.3   kube-ovn-worker2   <none>           <none>
 gateway2-fcc6b8b87-wmww6   1/1     Running   0          2m18s   192.168.0.2   kube-ovn-worker    <none>           <none>
 
-$ kubectl ko nbctl lr-route-list vpc1
-IPv4 Routes
-Route Table <main>:
-           192.168.0.0/24               192.168.0.2 src-ip ecmp ecmp-symmetric-reply bfd
-           192.168.0.0/24               192.168.0.3 src-ip ecmp ecmp-symmetric-reply bfd
+$ kubectl ko nbctl lr-policy-list vpc1
+Routing Policies
+     29100                       ip4.src == 192.168.0.0/24         reroute                192.168.0.2, 192.168.0.3
+     29090                       ip4.src == 192.168.0.0/24            drop
 
 $ kubectl ko nbctl list bfd
 _uuid               : 223ede10-9169-4c7d-9524-a546e24bfab5


### PR DESCRIPTION
## Summary

- The BFD HA section of the VPC Egress Gateway doc showed an `lr-route-list vpc1` example with `src-ip ecmp ecmp-symmetric-reply bfd`, but the controller (`pkg/controller/vpc_egress_gateway.go`) only ever calls `AddLogicalRouterPolicy` — it never creates static routes, in either the default VPC or a custom VPC. `ecmp_symmetric_reply` is an option on `Logical_Router_Static_Route`, not on Logical Router Policy, so the example was internally inconsistent with the implementation.
- Replace the example with the actual `lr-policy-list vpc1` output (a reroute policy at priority 29100 plus the BFD-fallback drop policy at 29090).
- Remove the misleading "(自定义 VPC 中是静态路由)" / "(static routes for custom VPCs)" parenthetical above the earlier `lr-policy-list ovn-cluster` example — the same code path is used for both.

For VEG's internal side, ECMP symmetric-reply isn't needed anyway: the gateway pods SNAT egress traffic, so return packets come back to the gateway pod's own IP and never re-traverse the `ip4.src == <subnet>` reroute policy.

Reported by a user implementing similar route auto-injection for VPC NAT Gateway who noticed the doc/code mismatch.

## Test plan

- [ ] `python3 scripts/check-chinese-punctuation.py` passes
- [ ] `npx markdownlint-cli` (with the project's disabled rules and search-replace rule) passes on the changed files
- [ ] `mkdocs build -s` builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)