### PR TITLE
Update containerd instructions for stopping ovs-ovn

### DIFF
--- a/docs/ops/delete-worker-node.en.md
+++ b/docs/ops/delete-worker-node.en.md
@@ -33,22 +33,28 @@ systemctl stop docker
 ```
 
 ### Containerd
-> In case of containerd, stopping the services does not stop the running pods/containers; it is required to stop ovs-ovn manually.
 
-With conatinerd the following command needs to be executed to stop the `ovs-ovn` container:
+> In case of containerd, stopping the services does not stop the running pods/containers; it is required to stop `ovs-ovn` manually.
+
+With containerd the following commands need to be executed to stop the `ovs-ovn` container:
 
 1. Stop kubelet
-```bash
-systemctl stop kubelet
-```
+
+    ```bash
+    systemctl stop kubelet
+    ```
+
 2. Remove ovs-ovn pod
-```bash
-crictl rm -f $(crictl ps | grep openvswitch | awk '{print $1}')
-```
+
+    ```bash
+    crictl rm -f $(crictl ps | grep openvswitch | awk '{print $1}')
+    ```
+
 3. Stop containerd
-```bash
-systemctl stop containerd
-```
+
+    ```bash
+    systemctl stop containerd
+    ```
 
 ## Cleanup Files on Node
 

--- a/docs/ops/delete-worker-node.en.md
+++ b/docs/ops/delete-worker-node.en.md
@@ -32,10 +32,22 @@ systemctl stop kubelet
 systemctl stop docker
 ```
 
-If using containerd as the CRI, the following command needs to be executed to stop the `ovs-ovn` container:
+### Containerd
+> In case of containerd, stopping the services does not stop the running pods/containers; it is required to stop ovs-ovn manually.
 
+With conatinerd the following command needs to be executed to stop the `ovs-ovn` container:
+
+1. Stop kubelet
+```bash
+systemctl stop kubelet
+```
+2. Remove ovs-ovn pod
 ```bash
 crictl rm -f $(crictl ps | grep openvswitch | awk '{print $1}')
+```
+3. Stop containerd
+```bash
+systemctl stop containerd
 ```
 
 ## Cleanup Files on Node

--- a/docs/ops/delete-worker-node.md
+++ b/docs/ops/delete-worker-node.md
@@ -30,11 +30,29 @@ systemctl stop kubelet
 systemctl stop docker
 ```
 
-如果使用的 CRI 为 containerd，需要执行下面的命令来停止 `ovs-ovn` 容器：
+### Containerd
 
-```bash
-crictl rm -f $(crictl ps | grep openvswitch | awk '{print $1}')
-```
+> 使用 containerd 作为 CRI 时，停止上述服务并不会停止正在运行的 Pod/容器，需要手动停止 `ovs-ovn`。
+
+使用 containerd 时，需要执行下面的命令来停止 `ovs-ovn` 容器：
+
+1. 停止 kubelet
+
+    ```bash
+    systemctl stop kubelet
+    ```
+
+2. 删除 ovs-ovn Pod
+
+    ```bash
+    crictl rm -f $(crictl ps | grep openvswitch | awk '{print $1}')
+    ```
+
+3. 停止 containerd
+
+    ```bash
+    systemctl stop containerd
+    ```
 
 ## 清理 Node 上的残留数据
 


### PR DESCRIPTION
Added instructions for stopping ovs-ovn container when using containerd.

- [ ] Make sure you have followed the [Document Convention](../blob/master/docs/reference/document-convention.en.md)
