### PR TITLE
docs: fix comment syntax in YAML/JSON code blocks

### DIFF
--- a/docs/advance/cilium-networkpolicy.en.md
+++ b/docs/advance/cilium-networkpolicy.en.md
@@ -149,7 +149,7 @@ Refer to the document, modify the `CiliumNetworkPolicy` resource, and add namesp
   - fromEndpoints:
     - matchLabels:
         app: dynamic
-        k8s:io.kubernetes.pod.namespace: default    // control the Pod access in other namespace
+        k8s:io.kubernetes.pod.namespace: default    # control the Pod access in other namespace
         
 ```
 

--- a/docs/advance/cilium-networkpolicy.md
+++ b/docs/advance/cilium-networkpolicy.md
@@ -150,7 +150,7 @@ round-trip min/avg/max = 0.223/1.028/2.558 ms
   - fromEndpoints:
     - matchLabels:
         app: dynamic
-        k8s:io.kubernetes.pod.namespace: default    // 控制其他 Namespace 下的 Pod 访问
+        k8s:io.kubernetes.pod.namespace: default    # 控制其他 Namespace 下的 Pod 访问
 ```
 
 查看修改后的 `CiliumNetworkPolicy` 资源信息:

--- a/docs/guide/loadbalancer-service.en.md
+++ b/docs/guide/loadbalancer-service.en.md
@@ -37,10 +37,11 @@ metadata:
   name: lb-svc-attachment
   namespace: kube-system
 spec:
+  # master corresponds to the node's physical NIC; adjust based on the actual environment (e.g., eth0 / ens192 / bond0)
   config: '{
       "cniVersion": "0.3.0",
       "type": "macvlan",
-      "master": "eth0",                            # Physical network card, configure according to the actual situation
+      "master": "eth0",
       "mode": "bridge"
     }'
 ```

--- a/docs/guide/loadbalancer-service.md
+++ b/docs/guide/loadbalancer-service.md
@@ -23,7 +23,7 @@ containers:
   - --default-cidr=10.16.0.0/16
   - --default-gateway=10.16.0.1
   - --default-gateway-check=true
-  - --enable-lb-svc=true                  // 参数设置为 true
+  - --enable-lb-svc=true                  # 参数设置为 true
 ```
 
 ### 创建 NetworkAttachmentDefinition CRD 资源
@@ -37,10 +37,11 @@ metadata:
   name: lb-svc-attachment
   namespace: kube-system
 spec:
+  # master 对应节点物理网卡，需按实际环境修改（如 eth0 / ens192 / bond0）
   config: '{
       "cniVersion": "0.3.0",
       "type": "macvlan",
-      "master": "eth0",                         //物理网卡，根据实际情况配置
+      "master": "eth0",
       "mode": "bridge"
     }'
 ```

--- a/docs/guide/static-ip-mac.en.md
+++ b/docs/guide/static-ip-mac.en.md
@@ -21,7 +21,7 @@ kind: Pod
 metadata:
   name: static-ip
   annotations:
-    ovn.kubernetes.io/ip_address: 10.16.0.15   // for dualstack use comma to separate addresses 10.16.0.15,fd00:10:16::000E
+    ovn.kubernetes.io/ip_address: 10.16.0.15   # for dualstack use comma to separate addresses 10.16.0.15,fd00:10:16::000E
     ovn.kubernetes.io/mac_address: 00:00:00:53:6B:B6
 spec:
   containers:
@@ -92,7 +92,7 @@ spec:
       labels:
         app: starter-backend
       annotations:
-        ovn.kubernetes.io/ip_pool: 10.16.0.15,10.16.0.16,10.16.0.17 // for dualstack ippool use semicolon to separate addresses 10.16.0.15,fd00:10:16::000E;10.16.0.16,fd00:10:16::000F;10.16.0.17,fd00:10:16::0010
+        ovn.kubernetes.io/ip_pool: 10.16.0.15,10.16.0.16,10.16.0.17 # for dualstack ippool use semicolon to separate addresses 10.16.0.15,fd00:10:16::000E;10.16.0.16,fd00:10:16::000F;10.16.0.17,fd00:10:16::0010
     spec:
       containers:
       - name: backend

--- a/docs/guide/static-ip-mac.md
+++ b/docs/guide/static-ip-mac.md
@@ -21,7 +21,7 @@ kind: Pod
 metadata:
   name: static-ip
   annotations:
-    ovn.kubernetes.io/ip_address: 10.16.0.15   // 双栈地址使用逗号分隔 10.16.0.15,fd00:10:16::15
+    ovn.kubernetes.io/ip_address: 10.16.0.15   # 双栈地址使用逗号分隔 10.16.0.15,fd00:10:16::15
     ovn.kubernetes.io/mac_address: 00:00:00:53:6B:B6
 spec:
   containers:
@@ -91,7 +91,7 @@ spec:
       labels:
         app: ippool
       annotations:
-        ovn.kubernetes.io/ip_pool: 10.16.0.15,10.16.0.16,10.16.0.17 // 双栈地址使用分号进行分隔 10.16.0.15,fd00:10:16::000E;10.16.0.16,fd00:10:16::000F;10.16.0.17,fd00:10:16::0010
+        ovn.kubernetes.io/ip_pool: 10.16.0.15,10.16.0.16,10.16.0.17 # 双栈地址使用分号进行分隔 10.16.0.15,fd00:10:16::000E;10.16.0.16,fd00:10:16::000F;10.16.0.17,fd00:10:16::0010
     spec:
       containers:
       - name: ippool


### PR DESCRIPTION
Replace invalid `//` comments with `#` in YAML examples, and move inline comments out of JSON strings into proper YAML-level `#` comments.

- [x] Make sure you have followed the [Document Convention](../blob/master/docs/reference/document-convention.en.md)
