### PR TITLE
docs: fix comment syntax in cilium-networkpolicy bash block

### DIFF
--- a/docs/advance/cilium-networkpolicy.en.md
+++ b/docs/advance/cilium-networkpolicy.en.md
@@ -84,7 +84,7 @@ dynamic-7d8d7874f5-6dsg6       1/1     Running   0          7h20m   10.16.0.2   
 dynamic-7d8d7874f5-tjgtp       1/1     Running   0          7h46m   10.16.0.42   kube-ovn-worker          <none>           <none>            app=dynamic,pod-template-hash=7d8d7874f5
 label-test1-77b6764857-swq4k   1/1     Running   0          3h43m   10.16.0.12   kube-ovn-worker          <none>           <none>            app=test1,pod-template-hash=77b6764857
 
-// As the destination Pod for testing access.
+# As the destination Pod for testing access.
 test-54c98bc466-mft5s          1/1     Running   0          8h      10.16.0.41   kube-ovn-worker          <none>           <none>            app=test,pod-template-hash=54c98bc466
 ```
 

--- a/docs/advance/cilium-networkpolicy.md
+++ b/docs/advance/cilium-networkpolicy.md
@@ -84,7 +84,7 @@ dynamic-7d8d7874f5-6dsg6       1/1     Running   0          7h20m   10.16.0.2   
 dynamic-7d8d7874f5-tjgtp       1/1     Running   0          7h46m   10.16.0.42   kube-ovn-worker          <none>           <none>            app=dynamic,pod-template-hash=7d8d7874f5
 label-test1-77b6764857-swq4k   1/1     Running   0          3h43m   10.16.0.12   kube-ovn-worker          <none>           <none>            app=test1,pod-template-hash=77b6764857
 
-// 以下为测试访问目的 Pod
+# 以下为测试访问目的 Pod
 test-54c98bc466-mft5s          1/1     Running   0          8h      10.16.0.41   kube-ovn-worker          <none>           <none>            app=test,pod-template-hash=54c98bc466
 ```
 


### PR DESCRIPTION
Follow-up to #411, which fixed invalid `//` comments in YAML/JSON code blocks but missed one line in the same file.

`docs/advance/cilium-networkpolicy.{md,en.md}` line 87 uses `//` as a comment inside a ```bash block showing `kubectl get pod` output. The rest of that block already uses `#` for comments (e.g. `# kubectl get pod -o wide ...`), so this line is inconsistent and technically an invalid shell comment. This PR changes `//` → `#` in both the Chinese and English versions.

- [x] Make sure you have followed the [Document Convention](../blob/master/docs/reference/document-convention.en.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)